### PR TITLE
Rename vlan_tx_tag* calls to skb_vlan_tag* for Linux 4.0.0

### DIFF
--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -3291,6 +3291,9 @@ rtl8168_tx_vlan_tag(struct rtl8168_private *tp,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
         tag = (tp->vlgrp && vlan_tx_tag_present(skb)) ?
               TxVlanTag | swab16(vlan_tx_tag_get(skb)) : 0x00;
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
+        tag = (skb_vlan_tag_present(skb)) ?
+              TxVlanTag | swab16(skb_vlan_tag_get(skb)) : 0x00;
 #else
         tag = (vlan_tx_tag_present(skb)) ?
               TxVlanTag | swab16(vlan_tx_tag_get(skb)) : 0x00;

--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -3291,7 +3291,7 @@ rtl8168_tx_vlan_tag(struct rtl8168_private *tp,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
         tag = (tp->vlgrp && vlan_tx_tag_present(skb)) ?
               TxVlanTag | swab16(vlan_tx_tag_get(skb)) : 0x00;
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
         tag = (skb_vlan_tag_present(skb)) ?
               TxVlanTag | swab16(skb_vlan_tag_get(skb)) : 0x00;
 #else


### PR DESCRIPTION
The commit in torvalds/linux@df8a39defad46b83694ea6dd868d332976d62cc0 has renamed some net functions, so if you encounter such error while compiling the driver with linux-4.0.0 or upper :

```
  CC [M]  /root/network/r8168/src/r8168_n.o
/root/network/r8168/src/r8168_n.c: In function ‘rtl8168_tx_vlan_tag’:
/root/network/r8168/src/r8168_n.c:3295:9: error: implicit declaration of function ‘vlan_tx_tag_present’ [-Werror=implicit-function-declaration]
         tag = (vlan_tx_tag_present(skb)) ?
         ^
/root/network/r8168/src/r8168_n.c:3296:15: error: implicit declaration of function ‘vlan_tx_tag_get’ [-Werror=implicit-function-declaration]
               TxVlanTag | swab16(vlan_tx_tag_get(skb)) : 0x00;
               ^
cc1: some warnings being treated as errors
scripts/Makefile.build:258: recipe for target '/root/network/r8168/src/r8168_n.o' failed

```

you can simply apply this patch and try to recompile.

PS : I know this repository is simply a mirror, but I wanted to share the patch.