### PR TITLE
Correct compilation problems in linux kernel version 4.11

### DIFF
--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -25731,8 +25731,9 @@ process_pkt:
 
                         if (rtl8168_rx_vlan_skb(tp, desc, skb) < 0)
                                 rtl8168_rx_skb(tp, skb);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
                         dev->last_rx = jiffies;
+#endif
                         RTLDEV->stats.rx_bytes += pkt_size;
                         RTLDEV->stats.rx_packets++;
                 }


### PR DESCRIPTION
I've added a patch that corrects the driver compilation in Linux kernel 4.11. Would it be ok to merge that with the base code? 
It's important to note that I'm not the patch author, neither do I recall who would he be, I just found it, applied and thought would be good to have the correction in the base driver code.
I'm attaching the .patch file just in case (with the extension changed to .txt for github issues)
[patch_4_11.txt](https://github.com/mtorromeo/r8168/files/1100349/patch_4_11.txt)
