### PR TITLE
Adapting the code to Linux 4.15

### DIFF
--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -87,6 +87,8 @@
 #include <linux/seq_file.h>
 #endif
 
+unsigned long __devicepointer;
+
 /* Maximum number of multicast addresses to filter (vs. Rx-all-multicast).
    The RTL chips use a 64 element hash table based on the Ethernet CRC. */
 static const int multicast_filter_limit = 32;
@@ -407,8 +409,14 @@ MODULE_VERSION(RTL8168_VERSION);
 static void rtl8168_sleep_rx_enable(struct net_device *dev);
 static void rtl8168_dsm(struct net_device *dev, int dev_state);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+static void rtl8168_esd_timer(struct timer_list *timer);
+static void rtl8168_link_timer(struct timer_list *timer);
+#else
 static void rtl8168_esd_timer(unsigned long __opaque);
 static void rtl8168_link_timer(unsigned long __opaque);
+#endif//LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+
 static void rtl8168_tx_clear(struct rtl8168_private *tp);
 static void rtl8168_rx_clear(struct rtl8168_private *tp);
 
@@ -22964,7 +22972,12 @@ static inline void rtl8168_request_esd_timer(struct net_device *dev)
         struct rtl8168_private *tp = netdev_priv(dev);
         struct timer_list *timer = &tp->esd_timer;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+        __devicepointer = (unsigned long)dev;
+        timer_setup(timer, rtl8168_esd_timer, 0);
+#else
         setup_timer(timer, rtl8168_esd_timer, (unsigned long)dev);
+#endif//LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
         mod_timer(timer, jiffies + RTL8168_ESD_TIMEOUT);
 }
 
@@ -22978,7 +22991,12 @@ static inline void rtl8168_request_link_timer(struct net_device *dev)
         struct rtl8168_private *tp = netdev_priv(dev);
         struct timer_list *timer = &tp->link_timer;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+        __devicepointer = (unsigned long)dev;
+        timer_setup(timer, rtl8168_link_timer, 0);
+#else
         setup_timer(timer, rtl8168_link_timer, (unsigned long)dev);
+#endif//LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
         mod_timer(timer, jiffies + RTL8168_LINK_TIMEOUT);
 }
 
@@ -24717,12 +24735,19 @@ err_out:
 #define PCI_DEVICE_SERIAL_NUMBER (0x0164)
 
 static void
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+rtl8168_esd_timer(struct timer_list *timer)
+{
+        struct net_device *dev = (struct net_device *)__devicepointer;
+        struct rtl8168_private *tp = netdev_priv(dev);
+#else
 rtl8168_esd_timer(unsigned long __opaque)
 {
         struct net_device *dev = (struct net_device *)__opaque;
         struct rtl8168_private *tp = netdev_priv(dev);
-        struct pci_dev *pdev = tp->pci_dev;
         struct timer_list *timer = &tp->esd_timer;
+#endif//LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+        struct pci_dev *pdev = tp->pci_dev;
         unsigned long timeout = RTL8168_ESD_TIMEOUT;
         unsigned long flags;
         u8 cmd;
@@ -24856,11 +24881,18 @@ rtl8168_esd_timer(unsigned long __opaque)
 }
 
 static void
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+rtl8168_link_timer(struct timer_list *timer)
+{
+        struct net_device *dev = (struct net_device *)__devicepointer;
+        struct rtl8168_private *tp = netdev_priv(dev);
+#else
 rtl8168_link_timer(unsigned long __opaque)
 {
         struct net_device *dev = (struct net_device *)__opaque;
         struct rtl8168_private *tp = netdev_priv(dev);
         struct timer_list *timer = &tp->link_timer;
+#endif//LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
         unsigned long flags;
 
         spin_lock_irqsave(&tp->lock, flags);


### PR DESCRIPTION
Linux 4.15 dropped setup_timer
https://github.com/torvalds/linux/commit/513ae785c63c30741e46f43960213d4ae5382ec0#diff-ba8897e9349509c7ca4d37b0704bee9c

i've tried to adapt the code using timer_setup instead, wich acts a bit differently.

The callback functions are more or less the same, and i used a global variable, "__devicepointer", to pass the pointer.

There's probably a cleaner solution than this one, but it works.

I know you don't accept third party patches to this repo since it's supposed to be a simple mirror, so i'm already closing the request. i've just posted this because it can be useful to someone.