### PR TITLE
Adiciona suporte ao dispositivo "10ec:8136"

### DIFF
--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -397,6 +397,7 @@ static const struct {
 
 static struct pci_device_id rtl8168_pci_tbl[] = {
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8168), },
+        { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8136), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8161), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x2502), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x2600), },


### PR DESCRIPTION
The existing r8169 module did not work well with the device below, this r8168 module solved the problem but at first it is necessary to add the device ID in the source code because in the original source code the board 0x8136 was not included.

This file change allows the device below to work with this module, r8168