### PR TITLE
Fix missing skb_gso_segment function declaration

### DIFF
--- a/src/r8168_n.c
+++ b/src/r8168_n.c
@@ -81,6 +81,10 @@
 #include <linux/mdio.h>
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#include <net/gso.h>
+#endif
+
 #include <asm/io.h>
 #include <asm/irq.h>
 


### PR DESCRIPTION
This motivation from [this issue](https://github.com/mtorromeo/r8168/issues/54)